### PR TITLE
terminate in case of unhandled exceptions & log more

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,8 +23,7 @@
                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
                               "-Dorg.slf4j.simpleLogger.log.org.apache.http=info"
                               "-Dorg.slf4j.simpleLogger.log.com.amazonaws=info"
-                              "-Dorg.slf4j.simpleLogger.log.com.codahale=debug"]
-                   :resource-paths ["/Users/paul/Work/uswitch/blueshift-riemann-metrics/target/blueshift-riemann-metrics-0.1.0-SNAPSHOT-standalone.jar"]}
+                              "-Dorg.slf4j.simpleLogger.log.com.codahale=debug"]}
              :uberjar {:aot [uswitch.blueshift.main]
                        :dependencies [[ch.qos.logback/logback-classic "1.1.2"]]}}
   :main uswitch.blueshift.main)

--- a/src/uswitch/blueshift/main.clj
+++ b/src/uswitch/blueshift/main.clj
@@ -1,9 +1,20 @@
 (ns uswitch.blueshift.main
-  (:require [clojure.tools.logging :refer (info)]
+  (:require [clojure.tools.logging :refer (info error)]
             [clojure.tools.cli :refer (parse-opts)]
             [uswitch.blueshift.system :refer (build-system)]
             [com.stuartsierra.component :refer (start stop)])
   (:gen-class))
+
+(defn register-default-exception-handler!
+  [system]
+  (Thread/setDefaultUncaughtExceptionHandler
+   (reify Thread$UncaughtExceptionHandler
+     (uncaughtException [_ thread e]
+       (error "Unhanled exception in thread " (str thread))
+       (error e)
+       (error "Caucht unhandled exception! Stopping system and terminating!")
+       (stop system)
+       (System/exit 2)))))
 
 (def cli-options
   [["-c" "--config CONFIG" "Path to EDN configuration file"
@@ -23,5 +34,6 @@
     (let [{:keys [config]} options]
       (info "Starting Blueshift with configuration" config)
       (let [system (build-system (read-string (slurp config)))]
+        (register-default-exception-handler! system)
         (start system)
         (wait!)))))

--- a/src/uswitch/blueshift/main.clj
+++ b/src/uswitch/blueshift/main.clj
@@ -12,7 +12,7 @@
      (uncaughtException [_ thread e]
        (error "Unhanled exception in thread " (str thread))
        (error e)
-       (error "Caucht unhandled exception! Stopping system and terminating!")
+       (error "Caught unhandled exception! Stopping system and terminating!")
        (stop system)
        (System/exit 2)))))
 

--- a/src/uswitch/blueshift/s3.clj
+++ b/src/uswitch/blueshift/s3.clj
@@ -40,6 +40,7 @@
           (recur next-marker (concat results objects)))))))
 
 (defn files [credentials bucket directory]
+  (info (format "S3: fetching files for S3://%s/%s" bucket directory))
   (listing credentials bucket :prefix directory))
 
 (defn directories
@@ -73,6 +74,7 @@
   (letfn [(manifest? [{:keys [key]}]
             (re-matches #".*manifest\.edn$" key))]
     (when-let [manifest-file-key (:key (first (filter manifest? files)))]
+      (info (format "Loading manifest %s" manifest-file-key))
       (with-open [content (:content (get-object credentials bucket manifest-file-key))]
         (-> (read-edn content)
             (map->Manifest)


### PR DESCRIPTION
We are having an issue in production, where blueshift fails to start any KeyWatchers.

This has multiple issues:

 - its not obvious from the logs that this is an issue, nothing says that spawing of KeyWatchers is expected
 - the process is just idling where it should clearly stop or error
 - this is the only log line
 - KeyWatchers create a thread, but without error handling, unless a UnhandledExceptionHandler is registered any issues in that thread will not be visible

This PR:
 - increases the amount of logging
 - provides `Thread/setDefaultUncaughtExceptionHandler` which
  - logs errors
  - attempts to stop the system
  - system exits
