### PR TITLE
Use amazonica

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,8 +8,6 @@ pipeline:
     image: clojure
     commands:
       - lein uberjar
-      - git clone git://github.com/uswitch/blueshift-statsd-metrics.git metrics
-      - cd metrics && lein uberjar && cp -pr target/blueshift-statsd-metrics-0.1.0-SNAPSHOT-standalone.jar ../target/blueshift-statsd-metrics.jar
 
   fetch-blueshift-statsd-metrics:
     image: alpine/git

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,11 +4,21 @@ pipeline:
     commands:
       - lein test
 
-  build:
+  build-blueshift:
     image: clojure
     commands:
       - lein uberjar
       - git clone git://github.com/uswitch/blueshift-statsd-metrics.git metrics
+      - cd metrics && lein uberjar && cp -pr target/blueshift-statsd-metrics-0.1.0-SNAPSHOT-standalone.jar ../target/blueshift-statsd-metrics.jar
+
+  fetch-blueshift-statsd-metrics:
+    image: alpine/git
+    commands:
+      - git clone git://github.com/uswitch/blueshift-statsd-metrics.git metrics
+
+  build-blueshift-statsd-metrics:
+    image: clojure
+    commands:
       - cd metrics && lein uberjar && cp -pr target/blueshift-statsd-metrics-0.1.0-SNAPSHOT-standalone.jar ../target/blueshift-statsd-metrics.jar
 
   docker:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,25 +1,36 @@
 pipeline:
   test:
+    when:
+      event: push
     image: clojure
     commands:
       - lein test
 
   build-blueshift:
+    when:
+      event: push
     image: clojure
     commands:
       - lein uberjar
 
   fetch-blueshift-statsd-metrics:
+    when:
+      event: push
     image: alpine/git
     commands:
       - git clone git://github.com/uswitch/blueshift-statsd-metrics.git metrics
 
   build-blueshift-statsd-metrics:
+    when:
+      event: push
     image: clojure
     commands:
       - cd metrics && lein uberjar && cp -pr target/blueshift-statsd-metrics-0.1.0-SNAPSHOT-standalone.jar ../target/blueshift-statsd-metrics.jar
 
-  docker:
+  publish:
+    when:
+      branch: master
+      event: push
     image: plugins/docker
     repo: uswitch/blueshift
     tags:

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,12 +16,14 @@ pipeline:
   fetch-blueshift-statsd-metrics:
     when:
       event: push
+      branch: master
     image: alpine/git
     commands:
       - git clone git://github.com/uswitch/blueshift-statsd-metrics.git metrics
 
   build-blueshift-statsd-metrics:
     when:
+      branch: master
       event: push
     image: clojure
     commands:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Service to watch Amazon S3 and automate the load into Amazon Redshift.
 
 [Amazon Redshift](https://aws.amazon.com/redshift/) is a "a fast, fully managed, petabyte-scale data warehouse service" but importing data into it can be a bit tricky: e.g. if you want upsert behaviour you have to [implement it yourself with temporary tables](http://docs.aws.amazon.com/redshift/latest/dg/t_updating-inserting-using-staging-tables-.html), and we've had problems [importing across machines into the same tables](https://forums.aws.amazon.com/message.jspa?messageID=443795). Redshift also performs best when bulk importing lots of large files from S3.
 
-[Blueshift](https://github.com/uswitch/blueshift) is a little service(tm) that makes it easy to automate the loading of data from Amazon S3 and into Amazon Redshift. It will periodically check for data files within a designated bucket and, when new files are found, import them. It provides upsert behaviour by default. 
+[Blueshift](https://github.com/uswitch/blueshift) is a little service(tm) that makes it easy to automate the loading of data from Amazon S3 and into Amazon Redshift. It will periodically check for data files within a designated bucket and, when new files are found, import them. It provides upsert behaviour by default.
 
 Importing to Redshift now requires just the ability to write files to S3.
 
@@ -19,15 +19,13 @@ Importing to Redshift now requires just the ability to write files to S3.
 Blueshift requires minimal configuration. It will only monitor a single S3 bucket currently, so the configuration file (ordinarily stored in `./etc/config.edn`) looks like this:
 
 ```clojure
-{:s3 {:credentials   {:access-key ""
-                      :secret-key ""}
-      :bucket        "blueshift-data"
+{:s3 {:bucket        "blueshift-data"
       :key-pattern   ".*"
       :poll-interval {:seconds 30}}
  :telemetry {:reporters [uswitch.blueshift.telemetry/log-metrics-reporter]}}
 ```
 
-The S3 credentials are shared by Blueshift for watching for new files and for [Redshift's `COPY` command](http://docs.aws.amazon.com/redshift/latest/dg/t_loading-tables-from-s3.html). The `:key-pattern` option is used to filter for specific keys (so you can have a single bucket with data from different environments, systems etc.).
+The `:key-pattern` option is used to filter for specific keys (so you can have a single bucket with data from different environments, systems etc.).
 
 ### Building & Running
 
@@ -42,7 +40,7 @@ Alternatively, you can build an Uberjar that you can run:
     $ lein uberjar
     $ java -Dlogback.configurationFile=./etc/logback.xml -jar target/blueshift-0.1.0-standalone.jar --config ./etc/config.edn
 
-The uberjar includes [Logback](http://logback.qos.ch/) for logging. `./etc/logback.xml.example` provides a simple starter configuration file with a console appender. 
+The uberjar includes [Logback](http://logback.qos.ch/) for logging. `./etc/logback.xml.example` provides a simple starter configuration file with a console appender.
 
 ## Using
 
@@ -119,4 +117,3 @@ Copyright © 2014 [uSwitch.com](http://www.uswitch.com) Limited.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.
-

--- a/project.clj
+++ b/project.clj
@@ -3,27 +3,41 @@
   :url "https://github.com/uswitch/blueshift"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/tools.logging "0.2.6"]
-                 [com.stuartsierra/component "0.2.1"]
-                 [org.clojure/core.async "0.1.303.0-886421-alpha"]
-                 [org.clojure/tools.cli "0.3.1"]
-                 [clj-aws-s3 "0.3.9" :exclusions [commons-logging commons-codec joda-time]]
-                 [joda-time "2.6"]
-                 [commons-codec "1.3"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [cheshire "5.3.1"]
-                 [postgresql "8.0-318.jdbc3"]
-                 [prismatic/schema "0.2.2"]
-                 [metrics-clojure "2.0.2"]
-                 [com.codahale.metrics/metrics-jvm "3.0.2"]]
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-simple "1.7.7"]
-                                  [org.clojure/tools.namespace "0.2.3"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/tools.logging "1.0.0"]
+                 [com.stuartsierra/component "1.0.0"]
+                 [org.clojure/core.async "1.0.567"]
+                 [org.clojure/tools.cli "1.0.194"]
+                 ;[clj-aws-s3 "0.3.9" :exclusions [commons-logging commons-codec joda-time]] ; TODO delete
+                 [amazonica "0.3.152"]
+                 [joda-time "2.10.5"]
+                 [commons-codec "1.14"]
+                 [org.slf4j/jcl-over-slf4j "1.7.30"]
+                 [cheshire "5.10.0"]
+                 [postgresql "9.3-1102.jdbc41"]
+                 [prismatic/schema "1.1.12"]
+                 [metrics-clojure "2.10.0"]
+                 [com.codahale.metrics/metrics-jvm "3.0.2"]
+                                  ;; java 11 FIX
+                 ;; in 11 the java xml stuff is no longer included
+                 ;; https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
+                 [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
+                 [com.sun.xml.bind/jaxb-core "2.3.0.1"]
+                 [com.sun.xml.bind/jaxb-impl "2.3.2"]
+                 [javax.activation/activation "1.1.1"]
+                 ]
+  ;; deal with java 11
+  ;; https://www.deps.co/blog/how-to-upgrade-clojure-projects-to-use-java-11/
+  :managed-dependencies [[org.clojure/core.rrb-vector "0.1.1"]
+                         [org.flatland/ordered "1.5.7"]]
+
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-simple "1.7.30"]
+                                  [org.clojure/tools.namespace "1.0.0"]]
                    :source-paths ["./dev"]
                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
                               "-Dorg.slf4j.simpleLogger.log.org.apache.http=info"
                               "-Dorg.slf4j.simpleLogger.log.com.amazonaws=info"
                               "-Dorg.slf4j.simpleLogger.log.com.codahale=debug"]}
              :uberjar {:aot [uswitch.blueshift.main]
-                       :dependencies [[ch.qos.logback/logback-classic "1.1.2"]]}}
+                       :dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}}
   :main uswitch.blueshift.main)

--- a/project.clj
+++ b/project.clj
@@ -23,8 +23,7 @@
                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
                               "-Dorg.slf4j.simpleLogger.log.org.apache.http=info"
                               "-Dorg.slf4j.simpleLogger.log.com.amazonaws=info"
-                              "-Dorg.slf4j.simpleLogger.log.com.codahale=debug"]
-                   :resource-paths ["/Users/paul/Work/uswitch/blueshift-riemann-metrics/target/blueshift-riemann-metrics-0.1.0-SNAPSHOT-standalone.jar"]}
+                              "-Dorg.slf4j.simpleLogger.log.com.codahale=debug"]}
              :uberjar {:aot [uswitch.blueshift.main]
                        :dependencies [[ch.qos.logback/logback-classic "1.1.2"]]}}
   :main uswitch.blueshift.main)

--- a/src/uswitch/blueshift/main.clj
+++ b/src/uswitch/blueshift/main.clj
@@ -25,3 +25,17 @@
       (let [system (build-system (read-string (slurp config)))]
         (start system)
         (wait!)))))
+
+(comment
+  
+  (def system
+    (atom
+      (build-system {:s3 {:bucket        "uswitch-blueshift"
+                          :key-pattern   "production/insight-load/.*"
+                          :poll-interval {:seconds 10}}})))
+
+  (prn system)
+  (swap! system start)
+  
+  
+  )

--- a/src/uswitch/blueshift/s3.clj
+++ b/src/uswitch/blueshift/s3.clj
@@ -1,7 +1,9 @@
 (ns uswitch.blueshift.s3
   (:require [com.stuartsierra.component :refer (Lifecycle system-map using start stop)]
             [clojure.tools.logging :refer (info error warn debug errorf)]
-            [aws.sdk.s3 :refer (list-objects get-object delete-object)]
+            ;[aws.sdk.s3 :refer (list-objects get-object ;delete-object
+            ;                                 )]
+            [amazonica.aws.s3 :refer [list-objects-v2 get-object]]
             [clojure.set :refer (difference)]
             [clojure.core.async :refer (go-loop thread put! chan >!! <!! >! <! alts!! timeout close!)]
             [clojure.edn :as edn]
@@ -14,6 +16,23 @@
            [org.apache.http.conn ConnectionPoolTimeoutException]))
 
 (defrecord Manifest [table pk-columns columns jdbc-url options data-pattern strategy staging-select])
+
+(defn delete-object
+  [args]
+  (info "DEL obj " args))
+
+(defn list-objects
+  [credentials bucket options]
+  (list-objects-v2
+    (merge
+      {:bucket-name bucket}
+      options)))
+
+(comment
+
+  (list-objects nil "uswitch-blueshift" {:delimiter "/" :prefix ""})
+
+  )
 
 (def ManifestSchema {:table          s/Str
                      :pk-columns     [s/Str]

--- a/src/uswitch/blueshift/s3.clj
+++ b/src/uswitch/blueshift/s3.clj
@@ -1,9 +1,7 @@
 (ns uswitch.blueshift.s3
   (:require [com.stuartsierra.component :refer (Lifecycle system-map using start stop)]
             [clojure.tools.logging :refer (info error warn debug errorf)]
-            ;[aws.sdk.s3 :refer (list-objects get-object ;delete-object
-            ;                                 )]
-            [amazonica.aws.s3 :refer [list-objects-v2 get-object]]
+            [amazonica.aws.s3 :as s3]
             [clojure.set :refer (difference)]
             [clojure.core.async :refer (go-loop thread put! chan >!! <!! >! <! alts!! timeout close!)]
             [clojure.edn :as edn]
@@ -18,21 +16,8 @@
 (defrecord Manifest [table pk-columns columns jdbc-url options data-pattern strategy staging-select])
 
 (defn delete-object
-  [args]
-  (info "DEL obj " args))
-
-(defn list-objects
-  [credentials bucket options]
-  (list-objects-v2
-    (merge
-      {:bucket-name bucket}
-      options)))
-
-(comment
-
-  (list-objects nil "uswitch-blueshift" {:delimiter "/" :prefix ""})
-
-  )
+  [bucket key]
+  (s3/delete-object bucket key))
 
 (def ManifestSchema {:table          s/Str
                      :pk-columns     [s/Str]
@@ -47,33 +32,27 @@
   (when-let [error-info (s/check ManifestSchema manifest)]
     (throw (ex-info "Invalid manifest. Check map for more details." error-info))))
 
-(defn listing
-  [credentials bucket & opts]
-  (let [options (apply hash-map opts)]
-    (loop [marker   nil
-           results  nil]
-      (let [{:keys [next-marker truncated? objects]}
-            (list-objects credentials bucket (assoc options :marker marker))]
-        (if (not truncated?)
-          (concat results objects)
-          (recur next-marker (concat results objects)))))))
+(defn list-all-objects
+  [request]
+  (let [response (s3/list-objects request)
+        next-request (assoc request :marker (:next-marker response))]
+    (concat (:object-summaries response) (if (:truncated? response)
+                                           (lazy-seq (list-all-objects next-request))
+                                           []))))
 
-(defn files [credentials bucket directory]
-  (listing credentials bucket :prefix directory))
-
-(defn directories
-  ([credentials bucket]
-     (:common-prefixes (list-objects credentials bucket {:delimiter "/"})))
-  ([credentials bucket path]
-     {:pre [(.endsWith path "/")]}
-     (:common-prefixes (list-objects credentials bucket {:delimiter "/" :prefix path}))))
+(defn- directories
+  ([bucket]
+   (:common-prefixes (s3/list-objects {:bucket-name bucket :delimiter "/"})))
+  ([bucket directory]
+   {:pre [(.endsWith directory "/")]}
+   (:common-prefixes (s3/list-objects {:bucket-name bucket :delimiter "/" :prefix directory}))))
 
 (defn leaf-directories
-  [credentials bucket]
-  (loop [work (directories credentials bucket)
+  [bucket]
+  (loop [work (directories bucket)
          result nil]
     (if (seq work)
-      (let [sub-dirs (directories credentials bucket (first work))]
+      (let [sub-dirs (directories bucket (first work))]
         (recur (concat (rest work) sub-dirs)
                (if (seq sub-dirs)
                  result
@@ -88,21 +67,21 @@
     (assoc record key value)
     record))
 
-(defn manifest [credentials bucket files]
+(defn manifest [bucket files]
   (letfn [(manifest? [{:keys [key]}]
             (re-matches #".*manifest\.edn$" key))]
     (when-let [manifest-file-key (:key (first (filter manifest? files)))]
-      (with-open [content (:content (get-object credentials bucket manifest-file-key))]
+      (with-open [content (:input-stream (s3/get-object bucket manifest-file-key))]
         (-> (read-edn content)
             (map->Manifest)
             (assoc-if-nil :strategy "merge")
             (update-in [:data-pattern] re-pattern))))))
 
 (defn- step-scan
-  [credentials bucket directory]
+  [bucket directory]
   (try
-    (let [fs (files credentials bucket directory)]
-      (if-let [manifest (manifest credentials bucket fs)]
+    (let [fs (list-all-objects {:bucket-name bucket :prefix directory})]
+      (if-let [manifest (manifest bucket fs)]
         (do
           (validate manifest)
           (let [data-files  (filter (fn [{:keys [key]}]
@@ -129,23 +108,23 @@
 (def import-timer (timer [(str *ns*) "importing-files" "time"]))
 
 (defn- step-load
-  [credentials bucket table-manifest files]
+  [bucket table-manifest files]
   (let [redshift-manifest  (redshift/manifest bucket files)
-        {:keys [key url]}  (redshift/put-manifest credentials bucket redshift-manifest)]
+        {:keys [key url]}  (redshift/put-manifest bucket redshift-manifest)]
     (info "Importing" (count files) "data files to table" (:table table-manifest) "from manifest" url)
     (debug "Importing Redshift Manifest" redshift-manifest)
     (inc! importing-files (count files))
     (try (time! import-timer
-                (redshift/load-table credentials url table-manifest))
+                (redshift/load-table url table-manifest))
          (info "Successfully imported" (count files) "files")
-         (delete-object credentials bucket key)
+         (delete-object bucket key)
          (dec! importing-files (count files))
          {:state :delete
           :files files}
          (catch java.sql.SQLException e
            (error e "Error loading into" (:table table-manifest))
            (error (:table table-manifest) "Redshift manifest content:" redshift-manifest)
-           (delete-object credentials bucket key)
+           (delete-object bucket key)
            (dec! importing-files (count files))
            {:state :scan
             :pause? true})
@@ -156,32 +135,32 @@
            {:state :scan :pause? true}))))
 
 (defn- step-delete
-  [credentials bucket files]
+  [bucket files]
   (do
     (doseq [key files]
       (info "Deleting" (str "s3://" bucket "/" key))
       (try
-        (delete-object credentials bucket key)
+        (delete-object bucket key)
         (catch Exception e
           (warn "Couldn't delete" key "  - ignoring"))))
     {:state :scan, :pause? true}))
 
 (defn- progress
   [{:keys [state] :as world}
-   {:keys [credentials bucket directory] :as configuration}]
+   {:keys [bucket directory] :as configuration}]
   (case state
-    :scan   (step-scan   credentials bucket directory )
-    :load   (step-load   credentials bucket           (:table-manifest world) (:files world))
-    :delete (step-delete credentials bucket           (:files world))))
+    :scan   (step-scan   bucket directory )
+    :load   (step-load   bucket           (:table-manifest world) (:files world))
+    :delete (step-delete bucket           (:files world))))
 
-(defrecord KeyWatcher [credentials bucket directory
+(defrecord KeyWatcher [bucket directory
                        poll-interval-seconds
                        poll-interval-random-seconds]
   Lifecycle
   (start [this]
     (info "Starting KeyWatcher for" (str bucket "/" directory) "polling every" poll-interval-seconds "seconds")
     (let [control-ch    (chan)
-          configuration {:credentials credentials :bucket bucket :directory directory}]
+          configuration {:bucket bucket :directory directory}]
       (thread
        (loop [timer (timeout (*
                               (+ poll-interval-seconds
@@ -204,9 +183,9 @@
     (close-channels this :watcher-control-ch)))
 
 
-(defn spawn-key-watcher! [credentials bucket directory
+(defn spawn-key-watcher! [bucket directory
                           poll-interval-seconds poll-interval-random-seconds]
-  (start (KeyWatcher. credentials bucket directory
+  (start (KeyWatcher. bucket directory
                       poll-interval-seconds
                       poll-interval-random-seconds)))
 
@@ -218,13 +197,13 @@
   Lifecycle
   (start [this]
     (info "Starting KeyWatcherSpawner")
-    (let [{:keys [new-directories-ch bucket credentials]} bucket-watcher
+    (let [{:keys [new-directories-ch bucket]} bucket-watcher
           watchers (atom nil)]
       (go-loop [dirs (<! new-directories-ch)]
         (when dirs
           (doseq [dir dirs]
             (swap! watchers conj (spawn-key-watcher!
-                                  credentials bucket dir
+                                  bucket dir
                                   poll-interval-seconds
                                   poll-interval-random-seconds))
             (inc! directories-watched))
@@ -244,15 +223,15 @@
    {:poll-interval-seconds (-> config :s3 :poll-interval :seconds)
     :poll-interval-random-seconds (or (-> config :s3 :poll-interval :random-seconds) 0)}))
 
-(defn matching-directories [credentials bucket key-pattern]
-  (try (->> (leaf-directories credentials bucket)
+(defn matching-directories [bucket key-pattern]
+  (try (->> (leaf-directories bucket)
             (filter #(re-matches key-pattern %))
             (set))
        (catch Exception e
          (errorf e "Error checking for matching object keys in \"%s\"" bucket)
          #{})))
 
-(defrecord BucketWatcher [credentials bucket key-pattern poll-interval-seconds]
+(defrecord BucketWatcher [bucket key-pattern poll-interval-seconds]
   Lifecycle
   (start [this]
     (info "Starting BucketWatcher. Polling" bucket "every" poll-interval-seconds "seconds for keys matching" key-pattern)
@@ -260,7 +239,7 @@
           control-ch         (chan)]
       (thread
         (loop [dirs nil]
-          (let [available-dirs (matching-directories credentials bucket key-pattern)
+          (let [available-dirs (matching-directories bucket key-pattern)
                 new-dirs       (difference available-dirs dirs)]
             (when (seq new-dirs)
               (info "New directories:" new-dirs "spawning" (count new-dirs) "watchers")
@@ -276,8 +255,7 @@
 (defn bucket-watcher
   "Creates a process watching for objects in S3 buckets."
   [config]
-  (map->BucketWatcher {:credentials (-> config :s3 :credentials)
-                       :bucket (-> config :s3 :bucket)
+  (map->BucketWatcher {:bucket (-> config :s3 :bucket)
                        :poll-interval-seconds (-> config :s3 :poll-interval :seconds)
                        :key-pattern (or (re-pattern (-> config :s3 :key-pattern))
                                         #".*")}))


### PR DESCRIPTION
The `clj-aws-s3` library obliges us to supply AWS credentials directly. This is not good.

An alternative is to make use of the AWS default credential provider chain (see https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)

The Amazonica library uses this approach.

This PR replaces the S3 library with Amazonica.

