### PR TITLE
tell CI about secrets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,7 @@ pipeline:
     when:
       branch: master
       event: push
+    secrets: ["docker_username","docker_email", "docker_password"]
     image: plugins/docker
     repo: uswitch/blueshift
     tags:


### PR DESCRIPTION
We have secrets in place, but we need to specify in drone, which of thouse secrets should be passed through in each particular step.

This passes through the docker creds to the publish step, which should grant permission to publish a new image.